### PR TITLE
Yielding extract result

### DIFF
--- a/c_src/educkdb_nif.c
+++ b/c_src/educkdb_nif.c
@@ -18,6 +18,8 @@
  * duckdb_nif
 */
 
+#define _BSD_SOURCE
+
 #include <erl_nif.h>
 #include <sys/time.h>
 #include <string.h>

--- a/c_src/educkdb_nif.c
+++ b/c_src/educkdb_nif.c
@@ -18,7 +18,7 @@
  * duckdb_nif
 */
 
-#define _BSD_SOURCE
+#define _DEFAULT_SOURCE
 
 #include <erl_nif.h>
 #include <sys/time.h>

--- a/src/educkdb.app.src
+++ b/src/educkdb.app.src
@@ -1,7 +1,7 @@
 {application, educkdb,
  [
   {description, "DuckDB NIF Interface"},
-  {vsn, "0.1.0"},
+  {vsn, "0.1.1"},
   {modules, [educkdb]},
   {registered, []},
   {licenses, ["Apache"]},

--- a/test/educkdb_test.erl
+++ b/test/educkdb_test.erl
@@ -580,6 +580,37 @@ appender_append_boolean_test() ->
 
     ok.
 
+yielding_test() ->
+    {ok, Db} = educkdb:open(":memory:"),
+    {ok, Conn} = educkdb:connect(Db),
+    {ok, [], []} = q(Conn, "create table test(a integer);"),
+
+    Values = lists:seq(1, 5555),
+    {ok, Appender} = educkdb:appender_create(Conn, undefined, <<"test">>),
+    {ok, [], []} = q(Conn, "begin;"),
+    lists:foreach(fun(V) ->
+                          ok = educkdb:append_int32(Appender, V),
+                          ok = educkdb:appender_end_row(Appender)
+                  end,
+                  Values),
+    educkdb:appender_flush(Appender),
+    {ok, [], []} = q(Conn, "commit;"),
+
+    ?assertEqual({ok, [{column,<<"count">>,bigint}], [[length(Values)]]}, q(Conn, "select count(*) as count from test;")),
+
+    {ok, _, Rows} = q(Conn, "select * from test order by a;"),
+
+    ?assertEqual(length(Values), length(Rows)),
+
+    RowValues = lists:flatten(Rows),
+
+    Values = RowValues,
+
+
+    ok.
+
+
+
 garbage_collect_test() ->
     F = fun() ->
                 {ok, Db} = educkdb:open(":memory:"),

--- a/test/educkdb_test.erl
+++ b/test/educkdb_test.erl
@@ -585,7 +585,8 @@ yielding_test() ->
     {ok, Conn} = educkdb:connect(Db),
     {ok, [], []} = q(Conn, "create table test(a integer, b varchar, c varchar);"),
 
-    Values = lists:seq(1, 1_000_000),
+    %% Insert a lot of records to ensure yielding takes place records 
+    Values = lists:seq(1, 100000),
     {ok, Appender} = educkdb:appender_create(Conn, undefined, <<"test">>),
     {ok, [], []} = q(Conn, "begin;"),
     lists:foreach(fun(V) ->


### PR DESCRIPTION
- Return result sets via a yielding nif, so normal schedulers can be used to retrieve the result set.