### PR TITLE
Restructure data extract functions

### DIFF
--- a/c_src/educkdb_nif.c
+++ b/c_src/educkdb_nif.c
@@ -533,161 +533,141 @@ is_valid(uint64_t *validity_mask, idx_t row_idx) {
 
 static ERL_NIF_TERM
 extract_data_boolean(ErlNifEnv *env, bool *vector_data, uint64_t *validity_mask, uint64_t offset, uint64_t count) {
-    ERL_NIF_TERM data = enif_make_list(env, 0);
+    ERL_NIF_TERM data[count];
 
-    for(idx_t i=count+offset; i-- > offset; ) {
-        ERL_NIF_TERM cell;
-
-        if(validity_mask == NULL || is_valid(validity_mask, i)) {
-            if(*(vector_data + i)) {
-                cell = atom_true;
+    for(idx_t i = 0; i < count; i++) {
+        if(validity_mask == NULL || is_valid(validity_mask, i + offset)) {
+            if(*(vector_data + i + offset)) {
+                data[i] = atom_true;
             } else {
-                cell = atom_false;
+                data[i] = atom_false;
             }
         } else {
-            cell = atom_null;
+            data[i] = atom_null;
         }
-
-        data = enif_make_list_cell(env, cell, data);
     }
 
-    return data;
+    return enif_make_list_from_array(env, data, count);
 }
 
 static ERL_NIF_TERM
 extract_data_utinyint(ErlNifEnv *env, uint8_t *vector_data, uint64_t *validity_mask, uint64_t offset, uint64_t count) {
-    ERL_NIF_TERM data = enif_make_list(env, 0);
+    ERL_NIF_TERM data[count];
 
-    for(idx_t i=count+offset; i-- > offset; ) {
-        ERL_NIF_TERM cell;
-        if(validity_mask == NULL || is_valid(validity_mask, i)) {
-            cell = enif_make_uint(env, *(vector_data + i));
+    for(idx_t i = 0; i < count; i++) {
+        if(validity_mask == NULL || is_valid(validity_mask, i + offset)) {
+            data[i] = enif_make_uint(env, *(vector_data + i + offset));
         } else {
-            cell = atom_null;
+            data[i] = atom_null;
         }
-        data = enif_make_list_cell(env, cell, data);
     }
 
-    return data;
+    return enif_make_list_from_array(env, data, count);
 }
 
 static ERL_NIF_TERM
 extract_data_usmallint(ErlNifEnv *env, uint16_t *vector_data, uint64_t *validity_mask, uint64_t offset, uint64_t count) {
-    ERL_NIF_TERM data = enif_make_list(env, 0);
+    ERL_NIF_TERM data[count];
 
-    for(idx_t i=count+offset; i-- > offset; ) {
-        ERL_NIF_TERM cell;
-        if(validity_mask == NULL || is_valid(validity_mask, i)) {
-            cell = enif_make_uint(env, *(vector_data + i));
+    for(idx_t i = 0; i < count; i++) {
+        if(validity_mask == NULL || is_valid(validity_mask, i + offset)) {
+            data[i] = enif_make_uint(env, *(vector_data + i + offset));
         } else {
-            cell = atom_null;
+            data[i] = atom_null;
         }
-        data = enif_make_list_cell(env, cell, data);
     }
 
-    return data;
+    return enif_make_list_from_array(env, data, count);
 }
 
 static ERL_NIF_TERM
 extract_data_uinteger(ErlNifEnv *env, uint32_t *vector_data, uint64_t *validity_mask, uint64_t offset, uint64_t count) {
-    ERL_NIF_TERM data = enif_make_list(env, 0);
+    ERL_NIF_TERM data[count];
 
-    for(idx_t i=count+offset; i-- > offset; ) {
-        ERL_NIF_TERM cell;
-        if(validity_mask == NULL || is_valid(validity_mask, i)) {
-            cell = enif_make_uint(env, *(vector_data + i));
+    for(idx_t i = 0; i < count; i++) {
+        if(validity_mask == NULL || is_valid(validity_mask, i + offset)) {
+            data[i] = enif_make_uint(env, *(vector_data + i + offset));
         } else {
-            cell = atom_null;
+            data[i] = atom_null;
         }
-        data = enif_make_list_cell(env, cell, data);
     }
 
-    return data;
+    return enif_make_list_from_array(env, data, count);
 }
 
 static ERL_NIF_TERM
 extract_data_ubigint(ErlNifEnv *env, uint64_t *vector_data, uint64_t *validity_mask, uint64_t offset, uint64_t count) {
-    ERL_NIF_TERM data = enif_make_list(env, 0);
+    ERL_NIF_TERM data[count];
 
-    for(idx_t i=count+offset; i-- > offset; ) {
-        ERL_NIF_TERM cell;
-        if(validity_mask == NULL || is_valid(validity_mask, i)) {
-            cell = enif_make_uint64(env, *(vector_data + i));
+    for(idx_t i = 0; i < count; i++) {
+        if(validity_mask == NULL || is_valid(validity_mask, i + offset)) {
+            data[i] = enif_make_uint64(env, *(vector_data + i + offset));
         } else {
-            cell = atom_null;
+            data[i] = atom_null;
         }
-        data = enif_make_list_cell(env, cell, data);
     }
 
-    return data;
+    return enif_make_list_from_array(env, data, count);
 }
 
 static ERL_NIF_TERM
 extract_data_tinyint(ErlNifEnv *env, int8_t *vector_data, uint64_t *validity_mask, uint64_t offset, uint64_t count) {
-    ERL_NIF_TERM data = enif_make_list(env, 0);
+    ERL_NIF_TERM data[count];
 
-    for(idx_t i=count+offset; i-- > offset; ) {
-        ERL_NIF_TERM cell;
-        if(validity_mask == NULL || is_valid(validity_mask, i)) {
-            cell = enif_make_int(env, *(vector_data + i));
+    for(idx_t i=0; i < count; i++) {
+        if(validity_mask == NULL || is_valid(validity_mask, i + offset)) {
+            data[i] = enif_make_int(env, *(vector_data + i + offset));
         } else {
-            cell = atom_null;
+            data[i] = atom_null;
         }
-        data = enif_make_list_cell(env, cell, data);
     }
 
-    return data;
+    return enif_make_list_from_array(env, data, count);
 }
 
 static ERL_NIF_TERM
 extract_data_smallint(ErlNifEnv *env, int16_t *vector_data, uint64_t *validity_mask, uint64_t offset, uint64_t count) {
-    ERL_NIF_TERM data = enif_make_list(env, 0);
+    ERL_NIF_TERM data[count];
 
-    for(idx_t i=count+offset; i-- > offset; ) {
-        ERL_NIF_TERM cell;
-        if(validity_mask == NULL || is_valid(validity_mask, i)) {
-            cell = enif_make_int(env,  *(vector_data + i));
+    for(idx_t i=0; i < count; i++) {
+        if(validity_mask == NULL || is_valid(validity_mask, i + offset)) {
+            data[i] = enif_make_int(env, *(vector_data + i + offset));
         } else {
-            cell = atom_null;
+            data[i] = atom_null;
         }
-        data = enif_make_list_cell(env, cell, data);
     }
 
-    return data;
+    return enif_make_list_from_array(env, data, count);
 }
 
 static ERL_NIF_TERM
 extract_data_integer(ErlNifEnv *env, int32_t *vector_data, uint64_t *validity_mask, uint64_t offset, uint64_t count) {
-    ERL_NIF_TERM data = enif_make_list(env, 0);
+    ERL_NIF_TERM data[count];
 
-    for(idx_t i=count+offset; i-- > offset; ) {
-        ERL_NIF_TERM cell;
-        if(validity_mask == NULL || is_valid(validity_mask, i)) {
-            cell = enif_make_int(env,  *(vector_data + i));
+    for(idx_t i=0; i < count; i++) {
+        if(validity_mask == NULL || is_valid(validity_mask, i + offset)) {
+            data[i] = enif_make_int(env, *(vector_data + i + offset));
         } else {
-            cell = atom_null;
+            data[i] = atom_null;
         }
-        data = enif_make_list_cell(env, cell, data);
     }
 
-    return data;
+    return enif_make_list_from_array(env, data, count);
 }
 
 static ERL_NIF_TERM
 extract_data_bigint(ErlNifEnv *env, int64_t *vector_data, uint64_t *validity_mask, uint64_t offset, uint64_t count) {
-    ERL_NIF_TERM data = enif_make_list(env, 0);
+    ERL_NIF_TERM data[count];
 
-    for(idx_t i=count+offset; i-- > offset; ) {
-        ERL_NIF_TERM cell;
-        if(validity_mask == NULL || is_valid(validity_mask, i)) {
-            cell = enif_make_int64(env, *(vector_data + i));
+    for(idx_t i=0; i < count; i++) {
+        if(validity_mask == NULL || is_valid(validity_mask, i + offset)) {
+            data[i] = enif_make_int64(env, *(vector_data + i + offset));
         } else {
-            cell = atom_null;
+            data[i] = atom_null;
         }
-        data = enif_make_list_cell(env, cell, data);
     }
 
-    return data;
+    return enif_make_list_from_array(env, data, count);
 }
 
 static ERL_NIF_TERM

--- a/c_src/educkdb_nif.c
+++ b/c_src/educkdb_nif.c
@@ -203,6 +203,7 @@ duckdb_type_name(duckdb_type t) {
         case DUCKDB_TYPE_TIME:         return "time";
         case DUCKDB_TYPE_INTERVAL:     return "interval";
         case DUCKDB_TYPE_HUGEINT:      return "hugeint";
+        case DUCKDB_TYPE_UHUGEINT:     return "uhugeint";
         case DUCKDB_TYPE_VARCHAR:      return "varchar";
         case DUCKDB_TYPE_BLOB:         return "blob";
         case DUCKDB_TYPE_DECIMAL:      return "decimal";
@@ -213,10 +214,18 @@ duckdb_type_name(duckdb_type t) {
         case DUCKDB_TYPE_LIST:         return "list";
         case DUCKDB_TYPE_STRUCT:       return "struct";
         case DUCKDB_TYPE_MAP:          return "map";
+        case DUCKDB_TYPE_ARRAY:        return "array";
         case DUCKDB_TYPE_UUID:         return "uuid";
         case DUCKDB_TYPE_UNION:        return "union";
         case DUCKDB_TYPE_BIT:          return "bit";
+        case DUCKDB_TYPE_TIME_TZ:      return "time_tz";
+        case DUCKDB_TYPE_TIMESTAMP_TZ: return "timestamp_tz";
+        case DUCKDB_TYPE_VARINT:       return "varint";
+        case DUCKDB_TYPE_SQLNULL:      return "sqlnull";
     }
+
+    // When we are missing a DUCKDB_TYPE;
+    return "unknown";
 }
 
 static ERL_NIF_TERM

--- a/c_src/educkdb_nif.c
+++ b/c_src/educkdb_nif.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2023 Maas-Maarten Zeeman
+ * Copyright 2022-2024 Maas-Maarten Zeeman
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/c_src/educkdb_nif.c
+++ b/c_src/educkdb_nif.c
@@ -672,36 +672,32 @@ extract_data_bigint(ErlNifEnv *env, int64_t *vector_data, uint64_t *validity_mas
 
 static ERL_NIF_TERM
 extract_data_float(ErlNifEnv *env, float *vector_data, uint64_t *validity_mask, uint64_t offset, uint64_t count) {
-    ERL_NIF_TERM data = enif_make_list(env, 0);
+    ERL_NIF_TERM data[count];
 
-    for(idx_t i=count+offset; i-- > offset; ) {
-        ERL_NIF_TERM cell;
-        if(validity_mask == NULL || is_valid(validity_mask, i)) {
-            cell = enif_make_double(env, (double) *(vector_data + i));
+    for(idx_t i=0; i < count; i++) {
+        if(validity_mask == NULL || is_valid(validity_mask, i + offset)) {
+            data[i] = enif_make_double(env, (double) *(vector_data + i + offset));
         } else {
-            cell = atom_null;
+            data[i] = atom_null;
         }
-        data = enif_make_list_cell(env, cell, data);
     }
 
-    return data;
+    return enif_make_list_from_array(env, data, count);
 }
 
 static ERL_NIF_TERM
 extract_data_double(ErlNifEnv *env, double *vector_data, uint64_t *validity_mask, uint64_t offset, uint64_t count) {
-    ERL_NIF_TERM data = enif_make_list(env, 0);
+    ERL_NIF_TERM data[count];
 
-    for(idx_t i=count+offset; i-- > offset; ) {
-        ERL_NIF_TERM cell;
-        if(validity_mask == NULL || is_valid(validity_mask, i)) {
-            cell = enif_make_double(env,  *(vector_data + i));
+    for(idx_t i=0; i < count; i++) {
+        if(validity_mask == NULL || is_valid(validity_mask, i + offset)) {
+            data[i] = enif_make_double(env, *(vector_data + i + offset));
         } else {
-            cell = atom_null;
+            data[i] = atom_null;
         }
-        data = enif_make_list_cell(env, cell, data);
     }
 
-    return data;
+    return enif_make_list_from_array(env, data, count);
 }
 
 static ERL_NIF_TERM

--- a/c_src/educkdb_nif.c
+++ b/c_src/educkdb_nif.c
@@ -702,58 +702,52 @@ extract_data_double(ErlNifEnv *env, double *vector_data, uint64_t *validity_mask
 
 static ERL_NIF_TERM
 extract_data_timestamp(ErlNifEnv *env, duckdb_timestamp *vector_data, uint64_t *validity_mask, uint64_t offset, uint64_t count) {
-    ERL_NIF_TERM data = enif_make_list(env, 0);
+    ERL_NIF_TERM data[count];
 
-    for(idx_t i=count+offset; i-- > offset; ) {
-        ERL_NIF_TERM cell;
-        if(validity_mask == NULL || is_valid(validity_mask, i)) {
-            duckdb_timestamp_struct timestamp = duckdb_from_timestamp(*(vector_data + i));
-            cell = enif_make_tuple2(env,
+    for(idx_t i=0; i < count; i++) {
+        if(validity_mask == NULL || is_valid(validity_mask, i + offset)) {
+            duckdb_timestamp_struct timestamp = duckdb_from_timestamp(*(vector_data + i + offset));
+            data[i] = enif_make_tuple2(env,
                     make_date_tuple(env, timestamp.date),
                     make_time_tuple(env, timestamp.time));
         } else {
-            cell = atom_null;
+            data[i] = atom_null;
         }
-        data = enif_make_list_cell(env, cell, data);
     }
 
-    return data;
+    return enif_make_list_from_array(env, data, count);
 }
 
 static ERL_NIF_TERM
 extract_data_date(ErlNifEnv *env, duckdb_date *vector_data, uint64_t *validity_mask, uint64_t offset, uint64_t count) {
-    ERL_NIF_TERM data = enif_make_list(env, 0);
+    ERL_NIF_TERM data[count];
 
-    for(idx_t i=count+offset; i-- > offset; ) {
-        ERL_NIF_TERM cell;
-        if(validity_mask == NULL || is_valid(validity_mask, i)) {
-            duckdb_date_struct date = duckdb_from_date(*(vector_data + i));
-            cell = make_date_tuple(env, date);
+    for(idx_t i=0; i < count; i++) {
+        if(validity_mask == NULL || is_valid(validity_mask, i + offset)) {
+            duckdb_date_struct date = duckdb_from_date(*(vector_data + i + offset));
+            data[i] = make_date_tuple(env, date);
         } else {
-            cell = atom_null;
+            data[i] = atom_null;
         }
-        data = enif_make_list_cell(env, cell, data);
     }
 
-    return data;
+    return enif_make_list_from_array(env, data, count);
 }
 
 static ERL_NIF_TERM
 extract_data_time(ErlNifEnv *env, duckdb_time *vector_data, uint64_t *validity_mask, uint64_t offset, uint64_t count) {
-    ERL_NIF_TERM data = enif_make_list(env, 0);
+    ERL_NIF_TERM data[count];
 
-    for(idx_t i=count+offset; i-- > offset; ) {
-        ERL_NIF_TERM cell;
-        if(validity_mask == NULL || is_valid(validity_mask, i)) {
-            duckdb_time_struct time = duckdb_from_time(*(vector_data + i));
-            cell = make_time_tuple(env, time);
+    for(idx_t i=0; i < count; i++) {
+        if(validity_mask == NULL || is_valid(validity_mask, i + offset)) {
+            duckdb_time_struct time= duckdb_from_time(*(vector_data + i + offset));
+            data[i] = make_time_tuple(env, time);
         } else {
-            cell = atom_null;
+            data[i] = atom_null;
         }
-        data = enif_make_list_cell(env, cell, data);
     }
 
-    return data;
+    return enif_make_list_from_array(env, data, count);
 }
 
 static ERL_NIF_TERM

--- a/c_src/educkdb_nif.c
+++ b/c_src/educkdb_nif.c
@@ -528,7 +528,7 @@ extract_data_boolean(ErlNifEnv *env, bool *vector_data, uint64_t *validity_mask,
 
     for(idx_t i = 0; i < count; i++) {
         if(duckdb_validity_row_is_valid(validity_mask, i + offset)) {
-            if(*(vector_data + i + offset)) {
+            if(vector_data[i + offset]) {
                 data[i] = atom_true;
             } else {
                 data[i] = atom_false;
@@ -547,7 +547,7 @@ extract_data_utinyint(ErlNifEnv *env, uint8_t *vector_data, uint64_t *validity_m
 
     for(idx_t i = 0; i < count; i++) {
         if(duckdb_validity_row_is_valid(validity_mask, i + offset)) {
-            data[i] = enif_make_uint(env, *(vector_data + i + offset));
+            data[i] = enif_make_uint(env, vector_data[i + offset]);
         } else {
             data[i] = atom_null;
         }
@@ -562,7 +562,7 @@ extract_data_usmallint(ErlNifEnv *env, uint16_t *vector_data, uint64_t *validity
 
     for(idx_t i = 0; i < count; i++) {
         if(duckdb_validity_row_is_valid(validity_mask, i + offset)) {
-            data[i] = enif_make_uint(env, *(vector_data + i + offset));
+            data[i] = enif_make_uint(env, vector_data[i + offset]);
         } else {
             data[i] = atom_null;
         }
@@ -577,7 +577,7 @@ extract_data_uinteger(ErlNifEnv *env, uint32_t *vector_data, uint64_t *validity_
 
     for(idx_t i = 0; i < count; i++) {
         if(duckdb_validity_row_is_valid(validity_mask, i + offset)) {
-            data[i] = enif_make_uint(env, *(vector_data + i + offset));
+            data[i] = enif_make_uint(env, vector_data[i + offset]);
         } else {
             data[i] = atom_null;
         }
@@ -592,7 +592,7 @@ extract_data_ubigint(ErlNifEnv *env, uint64_t *vector_data, uint64_t *validity_m
 
     for(idx_t i = 0; i < count; i++) {
         if(duckdb_validity_row_is_valid(validity_mask, i + offset)) {
-            data[i] = enif_make_uint64(env, *(vector_data + i + offset));
+            data[i] = enif_make_uint64(env, vector_data[i + offset]);
         } else {
             data[i] = atom_null;
         }
@@ -607,7 +607,7 @@ extract_data_tinyint(ErlNifEnv *env, int8_t *vector_data, uint64_t *validity_mas
 
     for(idx_t i=0; i < count; i++) {
         if(duckdb_validity_row_is_valid(validity_mask, i + offset)) {
-            data[i] = enif_make_int(env, *(vector_data + i + offset));
+            data[i] = enif_make_int(env, vector_data[i + offset]);
         } else {
             data[i] = atom_null;
         }
@@ -622,7 +622,7 @@ extract_data_smallint(ErlNifEnv *env, int16_t *vector_data, uint64_t *validity_m
 
     for(idx_t i=0; i < count; i++) {
         if(duckdb_validity_row_is_valid(validity_mask, i + offset)) {
-            data[i] = enif_make_int(env, *(vector_data + i + offset));
+            data[i] = enif_make_int(env, vector_data[i + offset]);
         } else {
             data[i] = atom_null;
         }
@@ -637,7 +637,7 @@ extract_data_integer(ErlNifEnv *env, int32_t *vector_data, uint64_t *validity_ma
 
     for(idx_t i=0; i < count; i++) {
         if(duckdb_validity_row_is_valid(validity_mask, i + offset)) {
-            data[i] = enif_make_int(env, *(vector_data + i + offset));
+            data[i] = enif_make_int(env, vector_data[i + offset]);
         } else {
             data[i] = atom_null;
         }
@@ -652,7 +652,7 @@ extract_data_bigint(ErlNifEnv *env, int64_t *vector_data, uint64_t *validity_mas
 
     for(idx_t i=0; i < count; i++) {
         if(duckdb_validity_row_is_valid(validity_mask, i + offset)) {
-            data[i] = enif_make_int64(env, *(vector_data + i + offset));
+            data[i] = enif_make_int64(env, vector_data[i + offset]);
         } else {
             data[i] = atom_null;
         }
@@ -667,7 +667,7 @@ extract_data_float(ErlNifEnv *env, float *vector_data, uint64_t *validity_mask, 
 
     for(idx_t i=0; i < count; i++) {
         if(duckdb_validity_row_is_valid(validity_mask, i + offset)) {
-            data[i] = enif_make_double(env, (double) *(vector_data + i + offset));
+            data[i] = enif_make_double(env, (double) vector_data[i + offset]);
         } else {
             data[i] = atom_null;
         }
@@ -682,7 +682,7 @@ extract_data_double(ErlNifEnv *env, double *vector_data, uint64_t *validity_mask
 
     for(idx_t i=0; i < count; i++) {
         if(duckdb_validity_row_is_valid(validity_mask, i + offset)) {
-            data[i] = enif_make_double(env, *(vector_data + i + offset));
+            data[i] = enif_make_double(env, vector_data[i + offset]);
         } else {
             data[i] = atom_null;
         }
@@ -697,7 +697,7 @@ extract_data_timestamp(ErlNifEnv *env, duckdb_timestamp *vector_data, uint64_t *
 
     for(idx_t i=0; i < count; i++) {
         if(duckdb_validity_row_is_valid(validity_mask, i + offset)) {
-            duckdb_timestamp_struct timestamp = duckdb_from_timestamp(*(vector_data + i + offset));
+            duckdb_timestamp_struct timestamp = duckdb_from_timestamp(vector_data[i + offset]);
             data[i] = enif_make_tuple2(env,
                     make_date_tuple(env, timestamp.date),
                     make_time_tuple(env, timestamp.time));
@@ -715,7 +715,7 @@ extract_data_date(ErlNifEnv *env, duckdb_date *vector_data, uint64_t *validity_m
 
     for(idx_t i=0; i < count; i++) {
         if(duckdb_validity_row_is_valid(validity_mask, i + offset)) {
-            duckdb_date_struct date = duckdb_from_date(*(vector_data + i + offset));
+            duckdb_date_struct date = duckdb_from_date(vector_data[i + offset]);
             data[i] = make_date_tuple(env, date);
         } else {
             data[i] = atom_null;
@@ -731,7 +731,7 @@ extract_data_time(ErlNifEnv *env, duckdb_time *vector_data, uint64_t *validity_m
 
     for(idx_t i=0; i < count; i++) {
         if(duckdb_validity_row_is_valid(validity_mask, i + offset)) {
-            duckdb_time_struct time= duckdb_from_time(*(vector_data + i + offset));
+            duckdb_time_struct time= duckdb_from_time(vector_data[i + offset]);
             data[i] = make_time_tuple(env, time);
         } else {
             data[i] = atom_null;
@@ -747,7 +747,7 @@ extract_data_hugeint(ErlNifEnv *env, duckdb_hugeint *vector_data, uint64_t *vali
 
     for(idx_t i=0; i < count; i++) {
         if(duckdb_validity_row_is_valid(validity_mask, i + offset)) {
-            duckdb_hugeint huge = *(vector_data + i + offset);
+            duckdb_hugeint huge = vector_data[i + offset];
             data[i] = enif_make_tuple3(env, atom_hugeint, enif_make_int64(env, huge.upper), enif_make_uint64(env, huge.lower));
         } else {
             data[i] = atom_null;
@@ -763,7 +763,7 @@ extract_data_uuid(ErlNifEnv *env, duckdb_hugeint *vector_data, uint64_t *validit
 
     for(idx_t i=0; i < count; i++) {
         if(duckdb_validity_row_is_valid(validity_mask, i + offset)) {
-            duckdb_hugeint huge = *(vector_data + i + offset);
+            duckdb_hugeint huge = vector_data[i + offset];
             char buf[16];
 
             // First bit is flipped because of sorting.
@@ -802,7 +802,7 @@ extract_data_varchar(ErlNifEnv *env, duckdb_string_t *vector_data, uint64_t *val
 
     for(idx_t i=0; i < count; i++) {
         if(duckdb_validity_row_is_valid(validity_mask, i + offset)) {
-            duckdb_string_t value = *(vector_data + i + offset);
+            duckdb_string_t value = vector_data[i + offset];
             data[i] = make_binary(env, duckdb_string_t_data(&value), duckdb_string_t_length(value));
         } else {
             data[i] = atom_null;
@@ -818,7 +818,7 @@ extract_data_uint8_enum(ErlNifEnv *env, duckdb_logical_type logical_type, uint8_
 
     for(idx_t i=0; i < count; i++) {
         if(duckdb_validity_row_is_valid(validity_mask, i + offset)) {
-            uint8_t enum_index = *(vector_data + i + offset);
+            uint8_t enum_index = vector_data[i + offset];
             char *value = duckdb_enum_dictionary_value(logical_type, (idx_t) enum_index);
             data[i] = make_binary(env, value, strlen(value));
             duckdb_free(value);
@@ -836,7 +836,7 @@ extract_data_uint16_enum(ErlNifEnv *env, duckdb_logical_type logical_type, uint1
 
     for(idx_t i=0; i < count; i++) {
         if(duckdb_validity_row_is_valid(validity_mask, i + offset)) {
-            uint16_t enum_index = *(vector_data + i + offset);
+            uint16_t enum_index = vector_data[i + offset];
             char *value = duckdb_enum_dictionary_value(logical_type, (idx_t) enum_index);
             data[i] = make_binary(env, value, strlen(value));
             duckdb_free(value);
@@ -854,7 +854,7 @@ extract_data_uint32_enum(ErlNifEnv *env, duckdb_logical_type logical_type, uint3
 
     for(idx_t i=0; i < count; i++) {
         if(duckdb_validity_row_is_valid(validity_mask, i + offset)) {
-            uint32_t enum_index = *(vector_data + i + offset);
+            uint32_t enum_index = vector_data[i + offset];
             char *value = duckdb_enum_dictionary_value(logical_type, (idx_t) enum_index);
             data[i] = make_binary(env, value, strlen(value));
             duckdb_free(value);
@@ -897,7 +897,7 @@ extract_data_list(ErlNifEnv *env, duckdb_vector vector, duckdb_logical_type logi
 
     for(idx_t i=0; i < count; i++) {
         if(duckdb_validity_row_is_valid(validity_mask, i + offset)) {
-            duckdb_list_entry_t entry = *(vector_data + i + offset);
+            duckdb_list_entry_t entry = vector_data[i + offset];
             data[i] = extract_data(env, list_child_type, child_vector, entry.offset, entry.length);
         } else {
             data[i] = atom_null;

--- a/c_src/educkdb_nif.c
+++ b/c_src/educkdb_nif.c
@@ -114,18 +114,9 @@ make_error_tuple(ErlNifEnv *env, const char *reason)
 static ERL_NIF_TERM
 make_binary(ErlNifEnv *env, const void *bytes, unsigned int size)
 {
-    ErlNifBinary blob;
-    ERL_NIF_TERM term;
-
-    if(!enif_alloc_binary(size, &blob)) {
-        return atom_error;
-    }
-
-    memcpy(blob.data, bytes, size);
-    term = enif_make_binary(env, &blob);
-    enif_release_binary(&blob);
-
-    return term;
+    ERL_NIF_TERM result;
+    memcpy(enif_make_new_binary(env, size, &result), bytes, size);
+    return result;
 }
 
 /*

--- a/c_src/educkdb_nif.c
+++ b/c_src/educkdb_nif.c
@@ -522,21 +522,12 @@ make_time_tuple(ErlNifEnv *env, duckdb_time_struct time) {
  * Extract result, chunk version 
  */
 
-
-// [todo] Make a macro for the repeated code.
-inline static bool
-is_valid(uint64_t *validity_mask, idx_t row_idx) {
-    idx_t entry_idx = row_idx / 64;
-    idx_t idx_in_entry = row_idx % 64;
-    return validity_mask[entry_idx] & (1 << idx_in_entry);
-}
-
 static ERL_NIF_TERM
 extract_data_boolean(ErlNifEnv *env, bool *vector_data, uint64_t *validity_mask, uint64_t offset, uint64_t count) {
     ERL_NIF_TERM data[count];
 
     for(idx_t i = 0; i < count; i++) {
-        if(validity_mask == NULL || is_valid(validity_mask, i + offset)) {
+        if(duckdb_validity_row_is_valid(validity_mask, i + offset)) {
             if(*(vector_data + i + offset)) {
                 data[i] = atom_true;
             } else {
@@ -555,7 +546,7 @@ extract_data_utinyint(ErlNifEnv *env, uint8_t *vector_data, uint64_t *validity_m
     ERL_NIF_TERM data[count];
 
     for(idx_t i = 0; i < count; i++) {
-        if(validity_mask == NULL || is_valid(validity_mask, i + offset)) {
+        if(duckdb_validity_row_is_valid(validity_mask, i + offset)) {
             data[i] = enif_make_uint(env, *(vector_data + i + offset));
         } else {
             data[i] = atom_null;
@@ -570,7 +561,7 @@ extract_data_usmallint(ErlNifEnv *env, uint16_t *vector_data, uint64_t *validity
     ERL_NIF_TERM data[count];
 
     for(idx_t i = 0; i < count; i++) {
-        if(validity_mask == NULL || is_valid(validity_mask, i + offset)) {
+        if(duckdb_validity_row_is_valid(validity_mask, i + offset)) {
             data[i] = enif_make_uint(env, *(vector_data + i + offset));
         } else {
             data[i] = atom_null;
@@ -585,7 +576,7 @@ extract_data_uinteger(ErlNifEnv *env, uint32_t *vector_data, uint64_t *validity_
     ERL_NIF_TERM data[count];
 
     for(idx_t i = 0; i < count; i++) {
-        if(validity_mask == NULL || is_valid(validity_mask, i + offset)) {
+        if(duckdb_validity_row_is_valid(validity_mask, i + offset)) {
             data[i] = enif_make_uint(env, *(vector_data + i + offset));
         } else {
             data[i] = atom_null;
@@ -600,7 +591,7 @@ extract_data_ubigint(ErlNifEnv *env, uint64_t *vector_data, uint64_t *validity_m
     ERL_NIF_TERM data[count];
 
     for(idx_t i = 0; i < count; i++) {
-        if(validity_mask == NULL || is_valid(validity_mask, i + offset)) {
+        if(duckdb_validity_row_is_valid(validity_mask, i + offset)) {
             data[i] = enif_make_uint64(env, *(vector_data + i + offset));
         } else {
             data[i] = atom_null;
@@ -615,7 +606,7 @@ extract_data_tinyint(ErlNifEnv *env, int8_t *vector_data, uint64_t *validity_mas
     ERL_NIF_TERM data[count];
 
     for(idx_t i=0; i < count; i++) {
-        if(validity_mask == NULL || is_valid(validity_mask, i + offset)) {
+        if(duckdb_validity_row_is_valid(validity_mask, i + offset)) {
             data[i] = enif_make_int(env, *(vector_data + i + offset));
         } else {
             data[i] = atom_null;
@@ -630,7 +621,7 @@ extract_data_smallint(ErlNifEnv *env, int16_t *vector_data, uint64_t *validity_m
     ERL_NIF_TERM data[count];
 
     for(idx_t i=0; i < count; i++) {
-        if(validity_mask == NULL || is_valid(validity_mask, i + offset)) {
+        if(duckdb_validity_row_is_valid(validity_mask, i + offset)) {
             data[i] = enif_make_int(env, *(vector_data + i + offset));
         } else {
             data[i] = atom_null;
@@ -645,7 +636,7 @@ extract_data_integer(ErlNifEnv *env, int32_t *vector_data, uint64_t *validity_ma
     ERL_NIF_TERM data[count];
 
     for(idx_t i=0; i < count; i++) {
-        if(validity_mask == NULL || is_valid(validity_mask, i + offset)) {
+        if(duckdb_validity_row_is_valid(validity_mask, i + offset)) {
             data[i] = enif_make_int(env, *(vector_data + i + offset));
         } else {
             data[i] = atom_null;
@@ -660,7 +651,7 @@ extract_data_bigint(ErlNifEnv *env, int64_t *vector_data, uint64_t *validity_mas
     ERL_NIF_TERM data[count];
 
     for(idx_t i=0; i < count; i++) {
-        if(validity_mask == NULL || is_valid(validity_mask, i + offset)) {
+        if(duckdb_validity_row_is_valid(validity_mask, i + offset)) {
             data[i] = enif_make_int64(env, *(vector_data + i + offset));
         } else {
             data[i] = atom_null;
@@ -675,7 +666,7 @@ extract_data_float(ErlNifEnv *env, float *vector_data, uint64_t *validity_mask, 
     ERL_NIF_TERM data[count];
 
     for(idx_t i=0; i < count; i++) {
-        if(validity_mask == NULL || is_valid(validity_mask, i + offset)) {
+        if(duckdb_validity_row_is_valid(validity_mask, i + offset)) {
             data[i] = enif_make_double(env, (double) *(vector_data + i + offset));
         } else {
             data[i] = atom_null;
@@ -690,7 +681,7 @@ extract_data_double(ErlNifEnv *env, double *vector_data, uint64_t *validity_mask
     ERL_NIF_TERM data[count];
 
     for(idx_t i=0; i < count; i++) {
-        if(validity_mask == NULL || is_valid(validity_mask, i + offset)) {
+        if(duckdb_validity_row_is_valid(validity_mask, i + offset)) {
             data[i] = enif_make_double(env, *(vector_data + i + offset));
         } else {
             data[i] = atom_null;
@@ -705,7 +696,7 @@ extract_data_timestamp(ErlNifEnv *env, duckdb_timestamp *vector_data, uint64_t *
     ERL_NIF_TERM data[count];
 
     for(idx_t i=0; i < count; i++) {
-        if(validity_mask == NULL || is_valid(validity_mask, i + offset)) {
+        if(duckdb_validity_row_is_valid(validity_mask, i + offset)) {
             duckdb_timestamp_struct timestamp = duckdb_from_timestamp(*(vector_data + i + offset));
             data[i] = enif_make_tuple2(env,
                     make_date_tuple(env, timestamp.date),
@@ -723,7 +714,7 @@ extract_data_date(ErlNifEnv *env, duckdb_date *vector_data, uint64_t *validity_m
     ERL_NIF_TERM data[count];
 
     for(idx_t i=0; i < count; i++) {
-        if(validity_mask == NULL || is_valid(validity_mask, i + offset)) {
+        if(duckdb_validity_row_is_valid(validity_mask, i + offset)) {
             duckdb_date_struct date = duckdb_from_date(*(vector_data + i + offset));
             data[i] = make_date_tuple(env, date);
         } else {
@@ -739,7 +730,7 @@ extract_data_time(ErlNifEnv *env, duckdb_time *vector_data, uint64_t *validity_m
     ERL_NIF_TERM data[count];
 
     for(idx_t i=0; i < count; i++) {
-        if(validity_mask == NULL || is_valid(validity_mask, i + offset)) {
+        if(duckdb_validity_row_is_valid(validity_mask, i + offset)) {
             duckdb_time_struct time= duckdb_from_time(*(vector_data + i + offset));
             data[i] = make_time_tuple(env, time);
         } else {
@@ -755,7 +746,7 @@ extract_data_hugeint(ErlNifEnv *env, duckdb_hugeint *vector_data, uint64_t *vali
     ERL_NIF_TERM data[count];
 
     for(idx_t i=0; i < count; i++) {
-        if(validity_mask == NULL || is_valid(validity_mask, i + offset)) {
+        if(duckdb_validity_row_is_valid(validity_mask, i + offset)) {
             duckdb_hugeint huge = *(vector_data + i + offset);
             data[i] = enif_make_tuple3(env, atom_hugeint, enif_make_int64(env, huge.upper), enif_make_uint64(env, huge.lower));
         } else {
@@ -771,7 +762,7 @@ extract_data_uuid(ErlNifEnv *env, duckdb_hugeint *vector_data, uint64_t *validit
     ERL_NIF_TERM data[count];
 
     for(idx_t i=0; i < count; i++) {
-        if(validity_mask == NULL || is_valid(validity_mask, i + offset)) {
+        if(duckdb_validity_row_is_valid(validity_mask, i + offset)) {
             duckdb_hugeint huge = *(vector_data + i + offset);
             char buf[16];
 
@@ -810,7 +801,7 @@ extract_data_varchar(ErlNifEnv *env, duckdb_string_t *vector_data, uint64_t *val
     ERL_NIF_TERM data[count];
 
     for(idx_t i=0; i < count; i++) {
-        if(validity_mask == NULL || is_valid(validity_mask, i + offset)) {
+        if(duckdb_validity_row_is_valid(validity_mask, i + offset)) {
             duckdb_string_t value = *(vector_data + i + offset);
             data[i] = make_binary(env, duckdb_string_t_data(&value), duckdb_string_t_length(value));
         } else {
@@ -826,7 +817,7 @@ extract_data_uint8_enum(ErlNifEnv *env, duckdb_logical_type logical_type, uint8_
     ERL_NIF_TERM data[count];
 
     for(idx_t i=0; i < count; i++) {
-        if(validity_mask == NULL || is_valid(validity_mask, i + offset)) {
+        if(duckdb_validity_row_is_valid(validity_mask, i + offset)) {
             uint8_t enum_index = *(vector_data + i + offset);
             char *value = duckdb_enum_dictionary_value(logical_type, (idx_t) enum_index);
             data[i] = make_binary(env, value, strlen(value));
@@ -844,7 +835,7 @@ extract_data_uint16_enum(ErlNifEnv *env, duckdb_logical_type logical_type, uint1
     ERL_NIF_TERM data[count];
 
     for(idx_t i=0; i < count; i++) {
-        if(validity_mask == NULL || is_valid(validity_mask, i + offset)) {
+        if(duckdb_validity_row_is_valid(validity_mask, i + offset)) {
             uint16_t enum_index = *(vector_data + i + offset);
             char *value = duckdb_enum_dictionary_value(logical_type, (idx_t) enum_index);
             data[i] = make_binary(env, value, strlen(value));
@@ -862,7 +853,7 @@ extract_data_uint32_enum(ErlNifEnv *env, duckdb_logical_type logical_type, uint3
     ERL_NIF_TERM data[count];
 
     for(idx_t i=0; i < count; i++) {
-        if(validity_mask == NULL || is_valid(validity_mask, i + offset)) {
+        if(duckdb_validity_row_is_valid(validity_mask, i + offset)) {
             uint32_t enum_index = *(vector_data + i + offset);
             char *value = duckdb_enum_dictionary_value(logical_type, (idx_t) enum_index);
             data[i] = make_binary(env, value, strlen(value));
@@ -905,7 +896,7 @@ extract_data_list(ErlNifEnv *env, duckdb_vector vector, duckdb_logical_type logi
     duckdb_logical_type list_child_type = duckdb_list_type_child_type(logical_type);
 
     for(idx_t i=0; i < count; i++) {
-        if(validity_mask == NULL || is_valid(validity_mask, i + offset)) {
+        if(duckdb_validity_row_is_valid(validity_mask, i + offset)) {
             duckdb_list_entry_t entry = *(vector_data + i + offset);
             data[i] = extract_data(env, list_child_type, child_vector, entry.offset, entry.length);
         } else {
@@ -925,7 +916,7 @@ extract_data_struct(ErlNifEnv *env, duckdb_vector vector, duckdb_logical_type lo
     idx_t child_count = duckdb_struct_type_child_count(logical_type);
 
     for(idx_t i=0; i < count; i++) {
-        if(validity_mask == NULL || is_valid(validity_mask, i + offset)) {
+        if(duckdb_validity_row_is_valid(validity_mask, i + offset)) {
             data[i] = enif_make_new_map(env);
 
             for(idx_t j=0; j < child_count; j++) {

--- a/c_src/educkdb_nif.c
+++ b/c_src/educkdb_nif.c
@@ -752,20 +752,18 @@ extract_data_time(ErlNifEnv *env, duckdb_time *vector_data, uint64_t *validity_m
 
 static ERL_NIF_TERM
 extract_data_hugeint(ErlNifEnv *env, duckdb_hugeint *vector_data, uint64_t *validity_mask, uint64_t offset, uint64_t count) {
-    ERL_NIF_TERM data = enif_make_list(env, 0);
+    ERL_NIF_TERM data[count];
 
-    for(idx_t i=count+offset; i-- > offset; ) {
-        ERL_NIF_TERM cell;
-        if(validity_mask == NULL || is_valid(validity_mask, i)) {
-            duckdb_hugeint huge = *(vector_data + i);
-            cell = enif_make_tuple3(env, atom_hugeint, enif_make_int64(env, huge.upper), enif_make_uint64(env, huge.lower));
+    for(idx_t i=0; i < count; i++) {
+        if(validity_mask == NULL || is_valid(validity_mask, i + offset)) {
+            duckdb_hugeint huge = *(vector_data + i + offset);
+            data[i] = enif_make_tuple3(env, atom_hugeint, enif_make_int64(env, huge.upper), enif_make_uint64(env, huge.lower));
         } else {
-            cell = atom_null;
+            data[i] = atom_null;
         }
-        data = enif_make_list_cell(env, cell, data);
     }
 
-    return data;
+    return enif_make_list_from_array(env, data, count);
 }
 
 static ERL_NIF_TERM

--- a/c_src/educkdb_nif.c
+++ b/c_src/educkdb_nif.c
@@ -1111,9 +1111,7 @@ extract_chunk_columns(ErlNifEnv *env, duckdb_data_chunk chunk, idx_t column_coun
         duckdb_logical_type logical_type = duckdb_vector_get_column_type(vector);
         duckdb_type type_id = duckdb_get_type_id(logical_type);
 
-        ERL_NIF_TERM data = extract_data(env, logical_type, vector, 0, tuple_count);
-
-        column[i] = data;
+        column[i] = extract_data(env, logical_type, vector, 0, tuple_count);
     }
 
     return enif_make_list_from_array(env, column, column_count); 
@@ -2487,14 +2485,14 @@ static ErlNifFunc nif_funcs[] = {
     {"disconnect", 1, educkdb_disconnect, ERL_NIF_DIRTY_JOB_IO_BOUND},
 
     // Queries
-    {"prepare", 2, educkdb_prepare},
+    {"prepare", 2, educkdb_prepare, ERL_NIF_DIRTY_JOB_IO_BOUND},
     {"query", 2, educkdb_query, ERL_NIF_DIRTY_JOB_IO_BOUND},
     {"execute_prepared", 1, educkdb_execute_prepared, ERL_NIF_DIRTY_JOB_IO_BOUND},
 
     // Result
     {"column_names", 1, educkdb_column_names},
-    {"fetch_chunk", 1, educkdb_fetch_chunk},
-    {"get_chunks", 1, educkdb_get_chunks},
+    {"fetch_chunk", 1, educkdb_fetch_chunk, ERL_NIF_DIRTY_JOB_IO_BOUND},
+    {"get_chunks", 1, educkdb_get_chunks, ERL_NIF_DIRTY_JOB_IO_BOUND},
 
     // Chunks
     {"chunk_column_count", 1, educkdb_chunk_get_column_count},

--- a/rebar.config.script
+++ b/rebar.config.script
@@ -1,8 +1,8 @@
 
 NifSharedSources = ["c_src/educkdb_nif.c"].
 NifStaticSources = NifSharedSources ++ ["c_src/duckdb/duckdb.cpp"].
-CFlagsDefault = "$CFLAGS -Os".
-CXXFlagsDefault = "$CXXFLAGS -Os -std=c++11".
+CFlagsDefault = "$CFLAGS -Os -fno-omit-frame-pointer".
+CXXFlagsDefault = "$CXXFLAGS -Os -std=c++11 -fno-omit-frame-pointer".
 DrvLdFlagsDefault = "-shared -lduckdb".
 
 DrvLdFlags =

--- a/rebar.config.script
+++ b/rebar.config.script
@@ -1,8 +1,8 @@
 
 NifSharedSources = ["c_src/educkdb_nif.c"].
 NifStaticSources = NifSharedSources ++ ["c_src/duckdb/duckdb.cpp"].
-CFlagsDefault = "$CFLAGS -Os -fno-omit-frame-pointer".
-CXXFlagsDefault = "$CXXFLAGS -Os -std=c++11 -fno-omit-frame-pointer".
+CFlagsDefault = "$CFLAGS -Os".
+CXXFlagsDefault = "$CXXFLAGS -Os -std=c++11".
 DrvLdFlagsDefault = "-shared -lduckdb".
 
 DrvLdFlags =

--- a/test/educkdb_test.erl
+++ b/test/educkdb_test.erl
@@ -1130,7 +1130,7 @@ blob_test() ->
 uhugeint_test() ->
     {ok, Db} = educkdb:open(":memory:"),
     {ok, Conn} = educkdb:connect(Db),
-    Expected = {ok, [#column{ name = <<"CAST(1 AS UHUGEINT)">>, type = invalid}], [ { {no_extract,uhugeint} } ]},
+    Expected = {ok, [#column{ name = <<"CAST(1 AS UHUGEINT)">>, type = uhugeint}], [ { {no_extract,uhugeint} } ]},
     ?assertMatch(Expected, educkdb:squery(Conn, "SELECT 1::uhugeint;")),
     ok.
 


### PR DESCRIPTION
Instead of filling a list from the end to the first element, use normal loops.